### PR TITLE
Update command line inputs/ouptuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CREPE Pitch Tracker [![Build Status](https://travis-ci.org/marl/crepe.svg?branch=master)](https://travis-ci.org/marl/crepe)
 ===================
 
-CREPE is a monophonic pitch tracker based on a deep convolutional neural network operating directly on the time-domain waveform input. CREPE is state-of-the-art (as of early 2018), outperfoming popular pitch trackers such as pYIN and SWIPE:
+CREPE is a monophonic pitch tracker based on a deep convolutional neural network operating directly on the time-domain waveform input. CREPE is state-of-the-art (as of 2018), outperfoming popular pitch trackers such as pYIN and SWIPE:
 
 <p align="center"><img src="https://user-images.githubusercontent.com/3009670/36563051-ee6a69a0-17e6-11e8-8d7b-9a37d16ee7ad.png" width="500"></p>
 
@@ -28,9 +28,9 @@ This repository includes a pre-trained version of the CREPE model for easy use. 
 $ python crepe.py audio_file.wav
 ```
 
-then, the resulting `audio_file.f0.csv` contains the predicted fundamental frequency, along with the confidence on the presence of voicing, is produced for each 10-millisecond frame. 
+The resulting `audio_file.f0.csv` contains 3 columns: the first with timestamps (a 10 ms hop size is used), the second contains the predicted fundamental frequency in Hz, and the third contains the voicing confidence, i.e. the confidence in the presence of a pitch:
 
-    # time,frequency,confidence
+    time,frequency,confidence
     0.00,185.616,0.907112
     0.01,186.764,0.844488
     0.02,188.356,0.798015
@@ -42,9 +42,15 @@ then, the resulting `audio_file.f0.csv` contains the predicted fundamental frequ
     0.08,199.678,0.775208
     ...
 
-In addition, the script saves the salience representation -- the activations in the last layer in the neural network -- is saved as `audio_file.salience.png`. This is how a salience representation looks like for an excerpt of a male singing voice:
+The script can also optionally save the output activation matrix of the model to an npy file (`--save-activation`), where the matrix dimensions are (n_frames, 360) using a hop size of 10 ms (there are 360 pitch bins covering 20 cents each).The script can also output a plot of the activation matrix (`--save-plot`), saved to `audio_file.activation.png` including an optional visual representation of the model's voicing detection (`--plot-voicing`). Here's an example plot of the activation matrix (without the voicing overlay) for an excerpt of male singing voice:
 
 ![salience](https://user-images.githubusercontent.com/266841/38465913-6fa085b0-3aef-11e8-9633-bdd59618ea23.png)
+
+For batch processing of files, you can provide a folder path instead of a file path: 
+```bash
+$ python crepe.py audio_folder
+```
+The script will process all WAV files found inside the folder. 
 
 For more information on the usage, please refer to the help message:
 

--- a/crepe.py
+++ b/crepe.py
@@ -170,7 +170,7 @@ def process_file(model, file, args):
     # write prediction as TSV
     f0_file = output_path(file, ".f0.csv", args.output)
     with open(f0_file, 'w') as out:
-        print('# time,frequency,confidence', file=out)
+        print('time,frequency,confidence', file=out)
         for i, freq in enumerate(prediction_hz):
             print("%.2f,%.3f,%.6f" % (i * 0.01, freq, confidence[i]), file=out)
     print("CREPE: Saved the estimated frequencies and confidence values at "

--- a/crepe.py
+++ b/crepe.py
@@ -218,14 +218,17 @@ def main():
         if os.path.isdir(path):
             found = [file for file in os.listdir(path) if file.lower().endswith('.wav')]
             if len(found) == 0:
-                print('CREPE: No WAV files found in directory {}'.format(path), file=sys.stderr)
+                print('CREPE: No WAV files found in directory {}'.format(path),
+                      file=sys.stderr)
             files += [os.path.join(path, file) for file in found]
         elif os.path.isfile(path):
             if not path.lower().endswith('.wav'):
-                print('CREPE: Expecting WAV file(s) but got {}'.format(path), file=sys.stderr)
+                print('CREPE: Expecting WAV file(s) but got {}'.format(path),
+                      file=sys.stderr)
             files.append(path)
         else:
-            print('CREPE: File or directory not found: {}'.format(path), file=sys.stderr)
+            print('CREPE: File or directory not found: {}'.format(path),
+                  file=sys.stderr)
 
     if len(files) == 0:
         print('CREPE: No WAV files found in {}, aborting.'.format(args.wav_file_path))
@@ -234,7 +237,8 @@ def main():
     model = build_and_load_model()
 
     for i, file in enumerate(files):
-        print('CREPE: Processing {} ... ({}/{})'.format(file, i+1, len(files)), file=sys.stderr)
+        print('CREPE: Processing {} ... ({}/{})'.format(file, i+1, len(files)),
+              file=sys.stderr)
         process_file(model, file, args)
 
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -13,7 +13,8 @@ def test_sweep():
 
     result = np.loadtxt(f0_file, delimiter=',')
 
-    # the result should be confident enough about the presence of pitch in every frame
+    # the result should be confident enough about the presence of pitch in every
+    # frame
     assert np.mean(result[:, 2] > 0.5) > 0.99
 
     # the frequencies should be linear


### PR DESCRIPTION
This PR restructures the input/outputs for crepe when called via the command line.

The functionality is by and large similar to the existing, but the conventions are simplified and the behavior is made more consistent (i.e. by default only a CSV file is returned, and all option flags add more output, rather than some adding outputs and some removing outputs).

Finally, this PR updates the README to explain all the options supported by the updated API.

## System description

### Inputs
Necessary: wav file or directory containing files

### Outputs
Necessary: csv file with timestamp, f0 and voicing confidence
Optional: activation matrix (npy), activation matrix plot (with/without voicing)

### Processing:
Optional: viterbi decoding

## Proposed command line API

Necessary arguments:
`filename`: path to wav file or folder containing wav files

Optional arguments:
`--out <outputdir>`: directory for saving output file(s). Default is same directory as input file(s).
`--vibterbi`: perform viterbi decodibng. Default is no decoding.
`--activation`: save the activate matrix (npy) to disk. Default is not to save it.
`--plot`: save a plot of the activation matrix (png) to disk. Default is not to save it.
`--plot-voicing`: include voicing detection in the plot of the activation matrix 

