### PR TITLE
Ensure all functions in crepe.py have an explicit API

### DIFF
--- a/crepe.py
+++ b/crepe.py
@@ -187,7 +187,7 @@ def process_file(model, file, args):
     if args.save_plot:
         from scipy.misc import imsave
         
-        plot_file = output_path(file, ".salience.png", args.output)
+        plot_file = output_path(file, ".activation.png", args.output)
         # to draw the low pitches in the bottom
         salience = np.flip(salience, axis=1)
         inferno = matplotlib.cm.get_cmap('inferno')

--- a/crepe.py
+++ b/crepe.py
@@ -7,6 +7,13 @@ import os
 import re
 import sys
 from argparse import RawDescriptionHelpFormatter
+import numpy as np
+from numpy.lib.stride_tricks import as_strided
+from hmmlearn import hmm
+from resampy import resample
+from scipy.io import wavfile
+import matplotlib.cm
+from imageio import imwrite
 
 
 def build_and_load_model():
@@ -61,8 +68,6 @@ def to_local_average_cents(salience, center=None):
     find the weighted average cents near the argmax bin
     """
 
-    import numpy as np
-
     if not hasattr(to_local_average_cents, 'cents_mapping'):
         # the bin number-to-cents mapping
         to_local_average_cents.mapping = (
@@ -91,8 +96,6 @@ def to_viterbi_cents(salience):
     continuity.
     """
 
-    import numpy as np
-    from hmmlearn import hmm
 
     # uniform prior on the starting pitch
     starting = np.ones(360) / 360
@@ -153,11 +156,7 @@ def process_file(model, file, output=None, viterbi=False,
 
     """
 
-    import matplotlib.cm
-    import numpy as np
-    from numpy.lib.stride_tricks import as_strided
-    from resampy import resample
-    from scipy.io import wavfile
+
 
     model_srate = 16000  # the model is trained on 16kHz audio
 
@@ -214,7 +213,6 @@ def process_file(model, file, output=None, viterbi=False,
 
     # save the salience visualization in a PNG file
     if save_plot:
-        from imageio import imwrite
 
         plot_file = output_path(file, ".activation.png", output)
         # to draw the low pitches in the bottom

--- a/crepe.py
+++ b/crepe.py
@@ -214,7 +214,7 @@ def process_file(model, file, output=None, viterbi=False,
 
     # save the salience visualization in a PNG file
     if save_plot:
-        from scipy.misc import imsave
+        from imageio import imwrite
 
         plot_file = output_path(file, ".activation.png", output)
         # to draw the low pitches in the bottom
@@ -230,7 +230,7 @@ def process_file(model, file, output=None, viterbi=False,
             image[-10:, :, :] = (
                 inferno((confidence > 0.5).astype(np.float))[np.newaxis, :, :])
 
-        imsave(plot_file, 255 * image)
+        imwrite(plot_file, 255 * image)
         print("CREPE: Saved the salience plot at {}".format(plot_file))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ resampy>=0.2.0,<0.3.0
 h5py>=2.7.0,<3.0.0
 hmmlearn==0.2.0,<0.3.0
 imageio>=2.3.0
+scikit-learn>=0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib>=2.1.0
 resampy>=0.2.0,<0.3.0
 h5py>=2.7.0,<3.0.0
 hmmlearn==0.2.0,<0.3.0
+imageio>=2.3.0

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -8,7 +8,7 @@ def test_sweep():
     file = os.path.join(os.path.dirname(__file__), 'sweep.wav')
 
     model = crepe.build_and_load_model()
-    crepe.process_file(model, file, crepe.parser.parse_args([file, '--skip-salience']))
+    crepe.process_file(model, file)
     f0_file = os.path.join(os.path.dirname(__file__), 'sweep.f0.csv')
 
     result = np.loadtxt(f0_file, delimiter=',')

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -11,7 +11,7 @@ def test_sweep():
     crepe.process_file(model, file)
     f0_file = os.path.join(os.path.dirname(__file__), 'sweep.f0.csv')
 
-    result = np.loadtxt(f0_file, delimiter=',')
+    result = np.loadtxt(f0_file, delimiter=',', skiprows=1)
 
     # the result should be confident enough about the presence of pitch in every
     # frame


### PR DESCRIPTION
Right now some functions take an `args` dict directly, which makes the unction call opaque. This PR fixes this by replacing passing the `args` dict with an explicit API for every function in crepe.py.