### PR TITLE
Apply Viterbi algorithm to predict voiced/unvoiced state of every state based on confidence array

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ from scipy.io import wavfile
 sr, audio = wavfile.read('/path/to/audiofile.wav')
 time, frequency, confidence, activation = crepe.predict(audio, sr, viterbi=True)
 ```
+The Viterbi algorithm can also be used to predict which frames are unvoiced. The following commands will set the frequency of such frames to zero:
+```python
+is_voiced = crepe.predict_voicing(confidence)
+frequency *= is_voiced
+```
 
 ## Argmax-local Weighted Averaging
 

--- a/crepe/__init__.py
+++ b/crepe/__init__.py
@@ -1,2 +1,2 @@
 from .version import version as __version__
-from .core import get_activation, predict, process_file
+from .core import get_activation, predict, predict_voicing, process_file

--- a/crepe/cli.py
+++ b/crepe/cli.py
@@ -10,7 +10,8 @@ from .core import process_file
 
 def run(filename, output=None, model_capacity='full', viterbi=False,
         save_activation=False, save_plot=False, plot_voicing=False,
-        no_centering=False, step_size=10, verbose=True):
+        apply_voicing=False, no_centering=False, step_size=10,
+        verbose=True):
     """
     Collect the WAV files to process and run the model
 
@@ -36,6 +37,10 @@ def run(filename, output=None, model_capacity='full', viterbi=False,
         Include a visual representation of the voicing activity detection in
         the plot of the output activation matrix. False by default, only
         relevant if save_plot is True.
+    apply_voicing : bool
+        Apply viterbi algorithm to predict for every frame whether it was
+        voiced or unvoiced. Zero out silent frames and save the resulting
+        frequency array to a .npy file.
     no_centering : bool
         Don't pad the signal, meaning frames will begin at their timestamp
         instead of being centered around their timestamp (which is the
@@ -81,6 +86,7 @@ def run(filename, output=None, model_capacity='full', viterbi=False,
                      save_activation=save_activation,
                      save_plot=save_plot,
                      plot_voicing=plot_voicing,
+                     apply_voicing=apply_voicing,
                      step_size=step_size,
                      verbose=verbose)
 
@@ -143,6 +149,11 @@ def main():
     parser.add_argument('--plot-voicing', '-v', action='store_true',
                         help='Plot the voicing prediction on top of the '
                              'output activation matrix plot')
+    parser.add_argument('--apply-voicing', '-P', action='store_true',
+                        help='Apply viterbi algorithm to predict for every '
+                             'frame whether it was voiced or unvoiced. Zero '
+                             'out silent frames and save the resulting '
+                             'frequency array to a .npy file.')
     parser.add_argument('--no-centering', '-n', action='store_true',
                         help="Don't pad the signal, meaning frames will begin "
                              "at their timestamp instead of being centered "
@@ -168,6 +179,7 @@ def main():
         save_activation=args.save_activation,
         save_plot=args.save_plot,
         plot_voicing=args.plot_voicing,
+        apply_voicing=args.apply_voicing,
         no_centering=args.no_centering,
         step_size=args.step_size,
         verbose=not args.quiet)

--- a/crepe/core.py
+++ b/crepe/core.py
@@ -178,12 +178,12 @@ def predict_voicing(confidence):
 
     # mean and variance for unvoiced and voiced states
     means = np.array([[0.0], [1.0]])
-    vars = np.array([[0.25], [0.25]])
+    variances = np.array([[0.25], [0.25]])
 
     # fix the model parameters because we are not optimizing the model
     model = hmm.GaussianHMM(n_components=2)
     model.startprob_, model.covars_, model.transmat_, model.means_, model.n_features = \
-        starting, vars, transition, means, 1
+        starting, variances, transition, means, 1
 
     # find the Viterbi path
     voicing_states = model.predict(confidence.reshape(-1, 1), [len(confidence)])


### PR DESCRIPTION
This feature delimitates regions of activation and silence (in monophonic recordings). I am submitting a pull request in case it would be useful for others as well and am very open to feedback. 

The modification was added as a function in core: "predict_voicing". The function returns a sequence of 0s and 1s, depending on the predicted voicing state according to a Gaussian HMM model. 

Some more details about the function and API modification: "predict_voicing" can be called independently after calling "predict", as described in the update to the documentation.  It is also possible to set the "apply-voicing" flag if calling crepe from the command line. This will cause the program to call "predict_voicing", multiply the result with the "frequency" array, setting unvoiced frames to zero, and save the new array, "voiced_frequency", to disk.