### PR TITLE
Python 2 compatible Viterbi decoding

### DIFF
--- a/crepe/core.py
+++ b/crepe/core.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 
 import os
 import re


### PR DESCRIPTION
The lines

```python
    xx, yy = np.meshgrid(range(360), range(360))
    transition = np.maximum(12 - abs(xx - yy), 0)
    transition = transition / np.sum(transition, axis=1)[:, None]
```

result in an all-zero transition matrix in Python 2.7, if Python 3-style "true" division is not enabled.