### PR TITLE
[WIP] Decoding from the categorical posterior distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,8 @@ setup(
         'matplotlib>=2.1.0',
         'resampy>=0.2.0,<0.3.0',
         'h5py>=2.7.0,<3.0.0',
-        'hmmlearn>=0.2.0,<0.3.0',
         'imageio>=2.3.0',
+        'librosa>=0.6.2',
         'scikit-learn>=0.16'
     ],
     package_data={


### PR DESCRIPTION
Implements the proposed alternative to posterior decoding of the network output as suggested in #37.

Remaining tasks:

- [ ] Test on original data. My tests have all been conducted on speech data. This proposed alternative should be run on the same data as the original continuous decoding for fair comparison.
- [ ] I took the phrasing "a PR that replaces hmmlearn with librosa.sequence.viterbi" literally—so the hmmlearn decoding has been removed. Based on the performance comparison, we may want to allow both decoding options.