### PR TITLE
Use tensorflow.keras in order to support eager mode and 2.0 behavior.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.7"
 install:
-  - pip install tensorflow pytest
+  - pip install pytest
   - pip install .
 script:
   - pytest

--- a/crepe/core.py
+++ b/crepe/core.py
@@ -25,7 +25,7 @@ model_srate = 16000
 def build_and_load_model(model_capacity):
     """
     Build the CNN model and load the weights
-    
+
     Parameters
     ----------
     model_capacity : 'tiny', 'small', 'medium', 'large', or 'full'
@@ -38,12 +38,12 @@ def build_and_load_model(model_capacity):
 
     Returns
     -------
-    model : keras.models.Model
+    model : tensorflow.keras.models.Model
         The pre-trained keras model loaded in memory
     """
-    from keras.layers import Input, Reshape, Conv2D, BatchNormalization
-    from keras.layers import MaxPool2D, Dropout, Permute, Flatten, Dense
-    from keras.models import Model
+    from tensorflow.keras.layers import Input, Reshape, Conv2D, BatchNormalization
+    from tensorflow.keras.layers import MaxPool2D, Dropout, Permute, Flatten, Dense
+    from tensorflow.keras.models import Model
 
     if models[model_capacity] is None:
         capacity_multiplier = {
@@ -156,11 +156,11 @@ def to_viterbi_cents(salience):
 def get_activation(audio, sr, model_capacity='full', center=True, step_size=10,
                    verbose=1):
     """
-    
+
     Parameters
     ----------
     audio : np.ndarray [shape=(N,) or (N, C)]
-        The audio samples. Multichannel audio will be downmixed. 
+        The audio samples. Multichannel audio will be downmixed.
     sr : int
         Sample rate of the audio samples. The audio will be resampled if
         the sample rate is not 16 kHz, which is expected by the model.
@@ -216,11 +216,11 @@ def predict(audio, sr, model_capacity='full',
             viterbi=False, center=True, step_size=10, verbose=1):
     """
     Perform pitch estimation on given audio
-    
+
     Parameters
     ----------
     audio : np.ndarray [shape=(N,) or (N, C)]
-        The audio samples. Multichannel audio will be downmixed. 
+        The audio samples. Multichannel audio will be downmixed.
     sr : int
         Sample rate of the audio samples. The audio will be resampled if
         the sample rate is not 16 kHz, which is expected by the model.
@@ -242,7 +242,7 @@ def predict(audio, sr, model_capacity='full',
     Returns
     -------
     A 4-tuple consisting of:
-    
+
         time: np.ndarray [shape=(T,)]
             The timestamps on which the pitch was estimated
         frequency: np.ndarray [shape=(T,)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+tensorflow==2.0
+numpy>=1.14.0
+scipy>=1.0.0
+matplotlib>=2.1.0
+resampy>=0.2.0,<0.3.0
+h5py>=2.7.0,<3.0.0
+hmmlearn>=0.2.0,<0.3.0
+imageio>=2.3.0
+scikit-learn>=0.16

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'Tracker': 'https://github.com/marl/crepe/issues'
     },
     install_requires=[
-        'keras==2.1.5',
+        'tensorflow==2.0',
         'numpy>=1.14.0',
         'scipy>=1.0.0',
         'matplotlib>=2.1.0',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
-import os
-import sys
 import bz2
 import imp
+import os
+import sys
+
+import pkg_resources
 from setuptools import setup, find_packages
 
 try:
@@ -67,15 +69,10 @@ setup(
         'Tracker': 'https://github.com/marl/crepe/issues'
     },
     install_requires=[
-        'tensorflow==2.0',
-        'numpy>=1.14.0',
-        'scipy>=1.0.0',
-        'matplotlib>=2.1.0',
-        'resampy>=0.2.0,<0.3.0',
-        'h5py>=2.7.0,<3.0.0',
-        'hmmlearn>=0.2.0,<0.3.0',
-        'imageio>=2.3.0',
-        'scikit-learn>=0.16'
+        str(requirement)
+        for requirement in pkg_resources.parse_requirements(
+            open(os.path.join(os.path.dirname(__file__), "requirements.txt"))
+        )
     ],
     package_data={
         'crepe': weight_files


### PR DESCRIPTION
This will make CREPE compatible with TFDS (among other newer libraries) and unblock https://github.com/tensorflow/datasets/pull/1085.