### PR TITLE
Added wavio.read() as fallback for cases where scipy.wavfile cannot r…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ h5py>=2.7.0,<3.0.0
 hmmlearn>=0.2.0,<0.3.0
 imageio>=2.3.0
 scikit-learn>=0.16
+wavio==0.0.4


### PR DESCRIPTION
…ead a wave file.

`scipy.wavfile` cannot read 24-bit files and is in general prone to failure.
If it fails reading, let's fall back on `wavio`, a library that works most of the times.
wavio is just a wrapper around Python's `wave` standard library.