### PR TITLE
Fix viterbi with hmmlearn==0.2.8

### DIFF
--- a/crepe/core.py
+++ b/crepe/core.py
@@ -141,7 +141,7 @@ def to_viterbi_cents(salience):
                 ((1 - self_emission) / 360))
 
     # fix the model parameters because we are not optimizing the model
-    model = hmm.MultinomialHMM(360, starting, transition)
+    model = hmm.CategoricalHMM(360, starting, transition)
     model.startprob_, model.transmat_, model.emissionprob_ = \
         starting, transition, emission
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ scipy>=1.0.0
 matplotlib>=2.1.0
 resampy>=0.2.0,<0.3.0
 h5py
-hmmlearn>=0.2.0,<0.3.0
+hmmlearn>=0.2.8,<0.3.0
 imageio>=2.3.0
 scikit-learn>=0.16


### PR DESCRIPTION
In version 0.2.8 of hmmlearn, `MultinominalHMM` was [renamed](https://github.com/hmmlearn/hmmlearn/blob/main/CHANGES.rst#version-028) to `CategoricalHMM`. The new `MultinominalHMM` takes a different set of arguments, which causes an error when `viterbi=True`. Using `CategoricalHMM` fixes this.

For completeness, [here is the diff](https://github.com/hmmlearn/hmmlearn/commit/ed57a69e7f1df7faff1a4db39f3c7fa2ea282ef8#diff-da6a552bb95a97dc362abbdc765eb8b2c4ef53af365cdd284fe72bb670207ab3L335-R695) which shows that `MultinominalHMM` was only renamed and no other changes were made.