### PR TITLE
updated setup.py to use importlib instead of outdated imp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import bz2
-import imp
+from importlib.machinery import SourceFileLoader
 import os
 import sys
 
@@ -34,7 +34,8 @@ else:
                     target.write(source.read())
             print('Decompression complete')
 
-version = imp.load_source('crepe.version', os.path.join('crepe', 'version.py'))
+version = SourceFileLoader('crepe.version', os.path.join('crepe', 'version.py'))
+version = version.load_module()
 
 with open('README.md') as file:
     long_description = file.read()


### PR DESCRIPTION
When trying to install crepe via pip, it gives an error stating that the "imp" library will be deprecated by Python 3.12 and will not let users install the package. I changed the "imp" library import in setup.py to the "importlib" ilbrary, and it should work now :)