### PR TITLE
relax resampy version requirement to support python3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.14.0
 scipy>=1.0.0
 matplotlib>=2.1.0
-resampy>=0.2.0,<0.3.0
+resampy>=0.2.0
 h5py
 hmmlearn>=0.3.0
 imageio>=2.3.0


### PR DESCRIPTION
Currently crepe requires `resampy>=0.2.0,<0.3.0`. The problem is that versions of resampy within that range do not work with Python 3.12:

```
$ docker run --rm python:3.12 pip install resampy==0.2.2
Collecting resampy==0.2.2
  Downloading resampy-0.2.2.tar.gz (323 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 323.4/323.4 kB 3.0 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-jlno0zv0/resampy_5f2a2a60b1594dfc8ec1f1e16ad51fdb/setup.py", line 2, in <module>
          import imp
      ModuleNotFoundError: No module named 'imp'
      [end of output]
```

However `resampy==0.3.0` (and higher) works:

```
$  docker run --rm python:3.12 pip install resampy==0.3.0
...
Successfully installed llvmlite-0.43.0 numba-0.60.0 numpy-2.0.0 resampy-0.3.0
```

This PR relaxes the `resampy<0.3.0` requirement to allow crepe to work with python3.12